### PR TITLE
fix(start): fixed callback and options combinations on start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,12 @@ export class GraphQLServer {
     return this
   }
 
-  start(options?: Options, callback: ((options: Options) => void) = () => null): Promise<void> {
+  start(options: Options, callback?: ((options: Options) => void)): Promise<void>
+  start(callback?: ((options: Options) => void)): Promise<void>
+  start(optionsOrCallback?: Options | ((options: Options) => void), callback?: ((options: Options) => void)): Promise<void> {
+    const options = (optionsOrCallback && typeof optionsOrCallback === 'function') ? {} : optionsOrCallback
+    const callbackFunc = callback ? callback : (optionsOrCallback && typeof optionsOrCallback === 'function') ? optionsOrCallback : () => null
+
     const app = this.express
 
     this.options = { ...this.options, ...options }
@@ -190,14 +195,14 @@ export class GraphQLServer {
     return new Promise((resolve, reject) => {
       if (!this.options.subscriptions) {
         app.listen(this.options.port, () => {
-          callback(this.options)
+          callbackFunc(this.options)
           resolve()
         })
       } else {
         const combinedServer = createServer(app)
 
         combinedServer.listen(this.options.port, () => {
-          callback(this.options)
+          callbackFunc(this.options)
           resolve()
         })
 


### PR DESCRIPTION
server.start() 
All of the below now work correctly:
server.start({ port: 5000 }) 
server.start({ port: 5000 }, ({ port }) =>
console.log(`server started on port ${port}`)) 
server.start(({ port }) => console.log(`server
started on port ${port}`))

Closes #88